### PR TITLE
Fix repository URL to match actual GitHub repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Short-io/client-browser.git"
+    "url": "https://github.com/Short-io/browser-sdk.git"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.0",


### PR DESCRIPTION
The repository URL pointed to Short-io/client-browser instead of Short-io/browser-sdk, causing npm OIDC provenance publishing to fail with a 404.