### PR TITLE
Align publish workflow with working client-node config

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,11 +2,10 @@ name: Publish to npm
 
 on:
   release:
-    types: [published]
+    types: [created]
 
 jobs:
   publish:
-    if: github.event.release.draft == false && github.event.release.prerelease == false
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -16,14 +15,12 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
-          cache: npm
 
       - run: npm ci
 
       - name: Set version from release tag
         run: npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version
-
 
       - run: npm publish --provenance --access public

--- a/package.json
+++ b/package.json
@@ -27,10 +27,15 @@
   ],
   "author": "Short.io",
   "license": "MIT",
+  "private": false,
   "repository": {
     "type": "git",
-    "url": "https://github.com/Short-io/browser-sdk.git"
+    "url": "git+https://github.com/Short-io/browser-sdk.git"
   },
+  "bugs": {
+    "url": "https://github.com/Short-io/browser-sdk/issues"
+  },
+  "homepage": "https://github.com/Short-io/browser-sdk#readme",
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.0",
     "@rollup/plugin-typescript": "^11.0.0",


### PR DESCRIPTION
Switches release trigger from `published` to `created`, removes redundant draft/prerelease guard, and bumps to Node 24 to match the client-node workflow that publishes successfully via OIDC.