### PR TITLE
Extract conversion functions to standalone exports and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,26 @@ A lightweight TypeScript/JavaScript SDK for [Short.io](https://short.io)'s URL s
 
 ## Installation
 
+### CDN (no build step required)
+
+Use directly in the browser — no bundler needed:
+
+```html
+<script type="module">
+  import { createClient } from 'https://cdn.jsdelivr.net/npm/@short.io/client-browser/dist/index.esm.js';
+
+  const client = createClient({ publicKey: 'your-public-api-key' });
+
+  const link = await client.createLink({
+    originalURL: 'https://example.com/very-long-url',
+    domain: 'your-domain.com'
+  });
+  console.log(link.shortURL);
+</script>
+```
+
+### npm
+
 ```bash
 npm install @short.io/client-browser
 ```
@@ -103,7 +123,25 @@ const link = await client.createEncryptedLink({
 // link.shortURL → https://your-domain.com/abc123#<base64-key>
 ```
 
-### `client.trackConversion(options)`
+## Conversion Tracking
+
+Conversion functions are standalone — no client instance needed. Import them directly:
+
+```typescript
+import { trackConversion, getClickId, observeConversions } from '@short.io/client-browser';
+```
+
+Or via CDN:
+
+```html
+<script type="module">
+  import { observeConversions } from 'https://cdn.jsdelivr.net/npm/@short.io/client-browser/dist/index.esm.js';
+
+  observeConversions({ domain: 'your-domain.com' });
+</script>
+```
+
+### `trackConversion(options)`
 
 Tracks a conversion event using `navigator.sendBeacon()`. Reads the `clid` (click ID) query parameter from the current page URL to attribute the conversion.
 
@@ -126,7 +164,7 @@ Returns `ConversionTrackingResult`:
 ```
 
 ```typescript
-const result = client.trackConversion({
+const result = trackConversion({
   domain: 'your-domain.com',
   conversionId: 'purchase',
   value: 49.99
@@ -137,15 +175,15 @@ if (result.success) {
 }
 ```
 
-### `client.getClickId()`
+### `getClickId()`
 
 Returns the `clid` query parameter from the current page URL, or `null` if not present.
 
 ```typescript
-const clickId = client.getClickId();
+const clickId = getClickId();
 ```
 
-### `client.observeConversions(options)`
+### `observeConversions(options)`
 
 Enables declarative conversion tracking via HTML `data-` attributes. Scans the DOM for elements with `data-shortio-conversion` and automatically binds event listeners. Also watches for dynamically added elements using a `MutationObserver`.
 
@@ -178,7 +216,7 @@ Returns a `ConversionObserver` with a `disconnect()` method to remove all listen
 ```
 
 ```typescript
-const observer = client.observeConversions({ domain: 'your-domain.com' });
+const observer = observeConversions({ domain: 'your-domain.com' });
 
 // Later, to stop tracking:
 observer.disconnect();
@@ -191,17 +229,6 @@ observer.disconnect();
 | ES Modules | `dist/index.esm.js` | Modern bundlers (Vite, webpack, etc.) |
 | CommonJS | `dist/index.js` | Node.js / legacy bundlers |
 | UMD | `dist/index.umd.js` | Direct `<script>` tag usage |
-
-### Direct Browser Usage (UMD)
-
-```html
-<script src="https://unpkg.com/@short.io/client-browser/dist/index.umd.js"></script>
-<script>
-  const client = ShortioClient.createClient({
-    publicKey: 'your-public-api-key'
-  });
-</script>
-```
 
 ## TypeScript
 

--- a/src/__tests__/shortio.test.ts
+++ b/src/__tests__/shortio.test.ts
@@ -1,4 +1,4 @@
-import { ShortioClient, createClient, createSecure } from '../shortio';
+import { ShortioClient, createClient, createSecure, trackConversion, getClickId, observeConversions } from '../shortio';
 import type { CreateLinkRequest, ExpandLinkRequest, ConversionTrackingOptions } from '../types';
 import { http, HttpResponse } from 'msw';
 import { setupWorker } from 'msw/browser';
@@ -282,7 +282,7 @@ describe('ShortioClient', () => {
         conversionId: 'purchase'
       };
 
-      const result = client.trackConversion(options);
+      const result = trackConversion(options);
 
       expect(navigator.sendBeacon).toHaveBeenCalledWith(
         'https://example.com/.shortio/conversion?clid=test-click-id&c=purchase'
@@ -302,7 +302,7 @@ describe('ShortioClient', () => {
         domain: 'example.com'
       };
 
-      const result = client.trackConversion(options);
+      const result = trackConversion(options);
 
       expect(navigator.sendBeacon).toHaveBeenCalledWith(
         'https://example.com/.shortio/conversion?clid=test-click-id'
@@ -320,7 +320,7 @@ describe('ShortioClient', () => {
         conversionId: 'purchase'
       };
 
-      const result = client.trackConversion(options);
+      const result = trackConversion(options);
 
       expect(navigator.sendBeacon).not.toHaveBeenCalled();
       expect(result).toEqual({
@@ -329,7 +329,7 @@ describe('ShortioClient', () => {
       });
     });
 
-    it('should handle errors gracefully', () => {
+    it('should propagate sendBeacon errors', () => {
       history.replaceState({}, '', '?clid=test-click-id');
       vi.spyOn(navigator, 'sendBeacon').mockImplementation(() => {
         throw new Error('Network error');
@@ -340,18 +340,13 @@ describe('ShortioClient', () => {
         conversionId: 'purchase'
       };
 
-      const result = client.trackConversion(options);
-
-      expect(result).toEqual({
-        success: false,
-        domain: 'example.com'
-      });
+      expect(() => trackConversion(options)).toThrow('Network error');
     });
 
     it('should extract clid when URL has multiple query params', () => {
       history.replaceState({}, '', '?utm_source=twitter&clid=abc&ref=home');
 
-      const result = client.trackConversion({ domain: 'example.com' });
+      const result = trackConversion({ domain: 'example.com' });
 
       expect(result.success).toBe(true);
       expect(result.clid).toBe('abc');
@@ -362,7 +357,7 @@ describe('ShortioClient', () => {
     it('should return clid from URL params', () => {
       history.replaceState({}, '', '?clid=test-click-id&other=param');
 
-      const result = client.getClickId();
+      const result = getClickId();
 
       expect(result).toBe('test-click-id');
     });
@@ -370,13 +365,13 @@ describe('ShortioClient', () => {
     it('should return null when no clid in URL', () => {
       history.replaceState({}, '', '?other=param');
 
-      const result = client.getClickId();
+      const result = getClickId();
 
       expect(result).toBeNull();
     });
 
     it('should return null when search string is empty', () => {
-      expect(client.getClickId()).toBeNull();
+      expect(getClickId()).toBeNull();
     });
   });
 
@@ -477,7 +472,7 @@ describe('ShortioClient', () => {
     it('should append value as v param in beacon URL', () => {
       history.replaceState({}, '', '?clid=test-click-id');
 
-      const result = client.trackConversion({
+      const result = trackConversion({
         domain: 'example.com',
         conversionId: 'purchase',
         value: 49.99,
@@ -498,7 +493,7 @@ describe('ShortioClient', () => {
     it('should send value without conversionId', () => {
       history.replaceState({}, '', '?clid=test-click-id');
 
-      const result = client.trackConversion({
+      const result = trackConversion({
         domain: 'example.com',
         value: 10,
       });
@@ -512,15 +507,15 @@ describe('ShortioClient', () => {
     it('should not include v param when value is undefined', () => {
       history.replaceState({}, '', '?clid=test-click-id');
 
-      client.trackConversion({ domain: 'example.com' });
+      trackConversion({ domain: 'example.com' });
 
       const url = (navigator.sendBeacon as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
       expect(url).not.toContain('&v=');
     });
   });
 
-  describe('declarative conversion tracking', () => {
-    let observer: ReturnType<typeof client.observeConversions>;
+  describe('observeConversions', () => {
+    let observer: ReturnType<typeof observeConversions>;
 
     afterEach(() => {
       observer?.disconnect();
@@ -533,7 +528,7 @@ describe('ShortioClient', () => {
       form.setAttribute('data-shortio-conversion', 'signup');
       document.body.appendChild(form);
 
-      observer = client.observeConversions({ domain: 'example.com' });
+      observer = observeConversions({ domain: 'example.com' });
       form.dispatchEvent(new Event('submit'));
 
       expect(navigator.sendBeacon).toHaveBeenCalledWith(
@@ -547,7 +542,7 @@ describe('ShortioClient', () => {
       button.setAttribute('data-shortio-conversion', 'cta');
       document.body.appendChild(button);
 
-      observer = client.observeConversions({ domain: 'example.com' });
+      observer = observeConversions({ domain: 'example.com' });
       button.dispatchEvent(new Event('click'));
 
       expect(navigator.sendBeacon).toHaveBeenCalledWith(
@@ -561,7 +556,7 @@ describe('ShortioClient', () => {
       anchor.setAttribute('data-shortio-conversion', 'link-click');
       document.body.appendChild(anchor);
 
-      observer = client.observeConversions({ domain: 'example.com' });
+      observer = observeConversions({ domain: 'example.com' });
       anchor.dispatchEvent(new Event('click'));
 
       expect(navigator.sendBeacon).toHaveBeenCalledWith(
@@ -576,7 +571,7 @@ describe('ShortioClient', () => {
       input.setAttribute('data-shortio-conversion', 'field-change');
       document.body.appendChild(input);
 
-      observer = client.observeConversions({ domain: 'example.com' });
+      observer = observeConversions({ domain: 'example.com' });
       input.dispatchEvent(new Event('change'));
 
       expect(navigator.sendBeacon).toHaveBeenCalledWith(
@@ -591,7 +586,7 @@ describe('ShortioClient', () => {
       input.setAttribute('data-shortio-conversion', 'form-submit');
       document.body.appendChild(input);
 
-      observer = client.observeConversions({ domain: 'example.com' });
+      observer = observeConversions({ domain: 'example.com' });
       input.dispatchEvent(new Event('click'));
 
       expect(navigator.sendBeacon).toHaveBeenCalledWith(
@@ -606,7 +601,7 @@ describe('ShortioClient', () => {
       button.setAttribute('data-shortio-conversion-value', '29.99');
       document.body.appendChild(button);
 
-      observer = client.observeConversions({ domain: 'example.com' });
+      observer = observeConversions({ domain: 'example.com' });
       button.dispatchEvent(new Event('click'));
 
       expect(navigator.sendBeacon).toHaveBeenCalledWith(
@@ -621,7 +616,7 @@ describe('ShortioClient', () => {
       button.setAttribute('data-shortio-conversion-value', 'not-a-number');
       document.body.appendChild(button);
 
-      observer = client.observeConversions({ domain: 'example.com' });
+      observer = observeConversions({ domain: 'example.com' });
       button.dispatchEvent(new Event('click'));
 
       const url = (navigator.sendBeacon as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
@@ -634,7 +629,7 @@ describe('ShortioClient', () => {
       button.setAttribute('data-shortio-conversion', '');
       document.body.appendChild(button);
 
-      observer = client.observeConversions({ domain: 'example.com' });
+      observer = observeConversions({ domain: 'example.com' });
       button.dispatchEvent(new Event('click'));
 
       const url = (navigator.sendBeacon as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
@@ -643,7 +638,7 @@ describe('ShortioClient', () => {
 
     it('should pick up dynamically added elements via MutationObserver', async () => {
       history.replaceState({}, '', '?clid=test-click-id');
-      observer = client.observeConversions({ domain: 'example.com' });
+      observer = observeConversions({ domain: 'example.com' });
 
       const button = document.createElement('button');
       button.setAttribute('data-shortio-conversion', 'dynamic');
@@ -661,7 +656,7 @@ describe('ShortioClient', () => {
 
     it('should pick up descendants of dynamically added elements', async () => {
       history.replaceState({}, '', '?clid=test-click-id');
-      observer = client.observeConversions({ domain: 'example.com' });
+      observer = observeConversions({ domain: 'example.com' });
 
       const wrapper = document.createElement('div');
       const button = document.createElement('button');
@@ -684,7 +679,7 @@ describe('ShortioClient', () => {
       button.setAttribute('data-shortio-conversion', 'cta');
       document.body.appendChild(button);
 
-      observer = client.observeConversions({ domain: 'example.com' });
+      observer = observeConversions({ domain: 'example.com' });
       observer.disconnect();
 
       button.dispatchEvent(new Event('click'));
@@ -706,7 +701,7 @@ describe('ShortioClient', () => {
       button.setAttribute('data-shortio-conversion', 'cta');
       document.body.appendChild(button);
 
-      observer = client.observeConversions({ domain: 'example.com' });
+      observer = observeConversions({ domain: 'example.com' });
       button.dispatchEvent(new Event('click'));
 
       // sendBeacon should not be called since trackConversion returns early without clid

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { ShortioClient, createClient } from './shortio';
+export { ShortioClient, createClient, trackConversion, getClickId, observeConversions } from './shortio';
 export type {
   ShortioConfig,
   CreateLinkRequest,

--- a/src/shortio.ts
+++ b/src/shortio.ts
@@ -43,6 +43,105 @@ export const createSecure = async (originalURL: string): Promise<{ securedOrigin
   }
 };
 
+export function trackConversion(options: ConversionTrackingOptions): ConversionTrackingResult {
+  const urlParams = new URLSearchParams(window.location.search);
+  const clid = urlParams.get('clid');
+
+  if (!clid) {
+    return {
+      success: false,
+      domain: options.domain
+    };
+  }
+
+  const conversionUrl = `https://${options.domain}/.shortio/conversion`;
+  const params = new URLSearchParams({ clid });
+
+  if (options.conversionId) {
+    params.append('c', options.conversionId);
+  }
+
+  if (options.value !== undefined) {
+    params.append('v', String(options.value));
+  }
+
+  const fullUrl = `${conversionUrl}?${params}`;
+
+  navigator.sendBeacon(fullUrl);
+
+  return {
+    success: true,
+    conversionId: options.conversionId,
+    clid,
+    domain: options.domain,
+    value: options.value,
+  };
+}
+
+export function getClickId(): string | null {
+  const urlParams = new URLSearchParams(window.location.search);
+  return urlParams.get('clid');
+}
+
+export function observeConversions(options: ObserveConversionsOptions): ConversionObserver {
+  const listeners: Array<{ element: Element; event: string; handler: EventListener }> = [];
+
+  const getEvent = (el: Element): string => {
+    const tag = el.tagName.toLowerCase();
+    if (tag === 'form') return 'submit';
+    if (tag === 'input' && (el as HTMLInputElement).type !== 'submit') return 'change';
+    return 'click';
+  };
+
+  const bind = (el: Element): void => {
+    const conversionIdAttr = el.getAttribute('data-shortio-conversion');
+    const conversionId = conversionIdAttr || undefined;
+    const valueAttr = el.getAttribute('data-shortio-conversion-value');
+    const parsedValue = valueAttr !== null ? Number(valueAttr) : undefined;
+    const value = parsedValue !== undefined && !isNaN(parsedValue) ? parsedValue : undefined;
+    const event = getEvent(el);
+    const handler = (): void => {
+      trackConversion({ domain: options.domain, conversionId, value });
+    };
+    el.addEventListener(event, handler);
+    listeners.push({ element: el, event, handler });
+  };
+
+  const bindAll = (root: Element | Document): void => {
+    const elements = root.querySelectorAll('[data-shortio-conversion]');
+    elements.forEach(bind);
+  };
+
+  // Bind existing elements
+  bindAll(document);
+
+  // Observe dynamically added elements
+  const mutationObserver = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      mutation.addedNodes.forEach((node) => {
+        if (node.nodeType !== Node.ELEMENT_NODE) return;
+        const el = node as Element;
+        if (el.hasAttribute('data-shortio-conversion')) {
+          bind(el);
+        }
+        bindAll(el);
+      });
+    }
+  });
+
+  mutationObserver.observe(document.body, { childList: true, subtree: true });
+
+  return {
+    disconnect(): void {
+      mutationObserver.disconnect();
+      for (const { element, event, handler } of listeners) {
+        element.removeEventListener(event, handler);
+      }
+      listeners.length = 0;
+    },
+  };
+}
+
 export class ShortioClient {
   private config: ShortioConfig;
 
@@ -58,7 +157,7 @@ export class ShortioClient {
     options: RequestInit = {}
   ): Promise<T> {
     const url = `${this.config.baseUrl}${endpoint}`;
-    
+
     const response = await fetch(url, {
       ...options,
       headers: {
@@ -92,112 +191,6 @@ export class ShortioClient {
     });
 
     return this.makeRequest<ExpandLinkResponse>(`/links/expand?${params}`);
-  }
-
-  trackConversion(options: ConversionTrackingOptions): ConversionTrackingResult {
-    const urlParams = new URLSearchParams(window.location.search);
-    const clid = urlParams.get('clid');
-    
-    if (!clid) {
-      return {
-        success: false,
-        domain: options.domain
-      };
-    }
-
-    const conversionUrl = `https://${options.domain}/.shortio/conversion`;
-    const params = new URLSearchParams({ clid });
-    
-    if (options.conversionId) {
-      params.append('c', options.conversionId);
-    }
-
-    if (options.value !== undefined) {
-      params.append('v', String(options.value));
-    }
-
-    const fullUrl = `${conversionUrl}?${params}`;
-
-    try {
-      navigator.sendBeacon(fullUrl);
-
-      return {
-        success: true,
-        conversionId: options.conversionId,
-        clid,
-        domain: options.domain,
-        value: options.value,
-      };
-    } catch {
-      return {
-        success: false,
-        domain: options.domain
-      };
-    }
-  }
-
-  getClickId(): string | null {
-    const urlParams = new URLSearchParams(window.location.search);
-    return urlParams.get('clid');
-  }
-
-  observeConversions(options: ObserveConversionsOptions): ConversionObserver {
-    const listeners: Array<{ element: Element; event: string; handler: EventListener }> = [];
-
-    const getEvent = (el: Element): string => {
-      const tag = el.tagName.toLowerCase();
-      if (tag === 'form') return 'submit';
-      if (tag === 'input' && (el as HTMLInputElement).type !== 'submit') return 'change';
-      return 'click';
-    };
-
-    const bind = (el: Element): void => {
-      const conversionIdAttr = el.getAttribute('data-shortio-conversion');
-      const conversionId = conversionIdAttr || undefined;
-      const valueAttr = el.getAttribute('data-shortio-conversion-value');
-      const parsedValue = valueAttr !== null ? Number(valueAttr) : undefined;
-      const value = parsedValue !== undefined && !isNaN(parsedValue) ? parsedValue : undefined;
-      const event = getEvent(el);
-      const handler = (): void => {
-        this.trackConversion({ domain: options.domain, conversionId, value });
-      };
-      el.addEventListener(event, handler);
-      listeners.push({ element: el, event, handler });
-    };
-
-    const bindAll = (root: Element | Document): void => {
-      const elements = root.querySelectorAll('[data-shortio-conversion]');
-      elements.forEach(bind);
-    };
-
-    // Bind existing elements
-    bindAll(document);
-
-    // Observe dynamically added elements
-    const observer = new MutationObserver((mutations) => {
-      for (const mutation of mutations) {
-        mutation.addedNodes.forEach((node) => {
-          if (node.nodeType !== Node.ELEMENT_NODE) return;
-          const el = node as Element;
-          if (el.hasAttribute('data-shortio-conversion')) {
-            bind(el);
-          }
-          bindAll(el);
-        });
-      }
-    });
-
-    observer.observe(document.body, { childList: true, subtree: true });
-
-    return {
-      disconnect(): void {
-        observer.disconnect();
-        for (const { element, event, handler } of listeners) {
-          element.removeEventListener(event, handler);
-        }
-        listeners.length = 0;
-      },
-    };
   }
 
   async createEncryptedLink(request: CreateLinkRequest): Promise<CreateLinkResponse> {


### PR DESCRIPTION
Move trackConversion, getClickId, and observeConversions from ShortioClient methods to standalone exported functions that work without a client instance. Update README with CDN-first installation, jsdelivr examples, and document the new function-based conversion API.